### PR TITLE
fix: moving a comment to the top node

### DIFF
--- a/src/transformations/transformFile.ts
+++ b/src/transformations/transformFile.ts
@@ -24,8 +24,14 @@ export function transformFile(state: TransformState, file: ts.SourceFile): ts.So
 
 		// steal comments from original first statement so that comment directives work properly
 		if (firstStatement && statements[0]) {
-			ts.copyComments(firstStatement, statements[0]);
-			ts.removeAllComments(firstStatement);
+			const original = ts.getParseTreeNode(firstStatement);
+
+			if (original) {
+				ts.copyComments(original, statements[0]);
+				ts.removeAllComments(original);
+			} else {
+				ts.moveSyntheticComments(statements[0], firstStatement);
+			}
 		}
 	}
 

--- a/src/transformations/transformFile.ts
+++ b/src/transformations/transformFile.ts
@@ -26,11 +26,11 @@ export function transformFile(state: TransformState, file: ts.SourceFile): ts.So
 		if (firstStatement && statements[0]) {
 			const original = ts.getParseTreeNode(firstStatement);
 
+			ts.moveSyntheticComments(statements[0], firstStatement);
+
 			if (original) {
 				ts.copyComments(original, statements[0]);
 				ts.removeAllComments(original);
-			} else {
-				ts.moveSyntheticComments(statements[0], firstStatement);
 			}
 		}
 	}


### PR DESCRIPTION
transformer would crash the compiler if another transformer returned modified nodes before its work